### PR TITLE
Arrange log fields so that timestamps are all aligned

### DIFF
--- a/lib/log-levels.js
+++ b/lib/log-levels.js
@@ -9,8 +9,8 @@ exports.FATAL = 4
 exports.LOG_LEVELS_TRANSLATION =
     [
       'debug',
-      'info',
-      'warn',
+      'info ',
+      'warn ',
       'error',
       'fatal'
     ]

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -37,9 +37,9 @@ Logger.prototype.formatLog = function (level, moduleName, correlationId, timesta
   }
 
   return {
+    'timestamp': timestamp.toISOString(),
     'level': LOG_LEVELS.LOG_LEVELS_TRANSLATION[level],
     'module': moduleName,
-    'timestamp': timestamp.toISOString(),
     'correlationId': correlationId,
     'message': message
   }


### PR DESCRIPTION
Motivation is to make it easier to read logs. It's easier to follow the time if the timestamps are aligned with each other.